### PR TITLE
Append CPPFLAGS to CFLAGS + fix install

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -1,11 +1,15 @@
 export ZOPEN_STABLE_URL="https://github.com/Old-Man-Programmer/tree.git"
-export ZOPEN_STABLE_DEPS="make"
+export ZOPEN_STABLE_DEPS="make coreutils"
 export ZOPEN_BUILD_LINE="STABLE"
 export ZOPEN_RUNTIME_DEPS="bash"
-export ZOPEN_INSTALL=skip
 export ZOPEN_COMP=XLCLANG
 export ZOPEN_CONFIGURE="skip"
-export ZOPEN_EXTRA_CFLAGS="-D_ALL_SOURCE=1 -qascii -q64 -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -D_OPEN_SYS_FILE_EXT=1"
+export ZOPEN_CHECK="skip"
+export ZOPEN_INSTALL_OPTS="install PREFIX=\$ZOPEN_INSTALL_DIR"
+
+zopen_pre_patch() {
+  export CFLAGS="$CFLAGS $CPPFLAGS"
+}
 
 zopen_check_results()
 {
@@ -22,7 +26,5 @@ zopen_check_results()
 
 zopen_get_version()
 {
-  # Modify to echo the version of your tool/library
-  # Rather than hardcoding the version, obtain the version by running the tool/library
-  ./tree/tree --version
+  ./tree --version | cut -f2 -d' ' | sed -e "s/v//g"
 }

--- a/patches/Makefile.patch
+++ b/patches/Makefile.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index d17cfca..d2e232a 100644
+--- a/Makefile
++++ b/Makefile
+@@ -94,7 +94,7 @@ CFLAGS+=-ggdb -std=c11 -pedantic -Wall -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS
+ all:	tree
+ 
+ tree:	$(OBJS)
+-	$(CC) $(LDFLAGS) -o $(TREE_DEST) $(OBJS)
++	$(CC) $(LDFLAGS) -o $(TREE_DEST) $(OBJS) $(LIBS)
+ 
+ $(OBJS): %.o:	%.c tree.h
+ 	$(CC) $(CFLAGS) -c -o $@ $<

--- a/patches/zossupport.patch
+++ b/patches/zossupport.patch
@@ -1,29 +1,3 @@
-diff --git a/Makefile b/Makefile
-index d17cfca..98761fb 100644
---- a/Makefile
-+++ b/Makefile
-@@ -32,7 +32,7 @@ OBJS=tree.o list.o hash.o color.o file.o filter.o info.o unix.o xml.o json.o htm
- # Uncomment options below for your particular OS:
- 
- # Linux defaults:
--CFLAGS+=-ggdb -std=c11 -pedantic -Wall -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
-+#CFLAGS+=-ggdb -std=c11 -pedantic -Wall -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
- #CFLAGS+=-O3 -std=c11 -pedantic -Wall -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64
- #LDFLAGS+=-s
- 
-@@ -89,6 +89,12 @@ CFLAGS+=-ggdb -std=c11 -pedantic -Wall -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS
- #LD=ld -d64
- #LDFLAGS+=-lc
- 
-+# Uncomment for z/OS:
-+prefix = ~/tree
-+CC=xlclang
-+CFLAGS+=-D_ALL_SOURCE=1 -qascii -q64 -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -D_OPEN_SYS_FILE_EXT=1
-+LDFLAGS+=
-+
- #------------------------------------------------------------
- 
- all:	tree
 diff --git a/color.c b/color.c
 index ba2b072..d5a764b 100644
 --- a/color.c


### PR DESCRIPTION
* The Makefile does not consider CPPFLAGS so I've appended CPPFLAGS to CFLAGS in buildenv
* It also does not consider extra LIBS, so I've added LIBS to Makefile
* zopen install is unskipped and coreutils is added because `install` command is needed
* The zopen_get_version is altered as well